### PR TITLE
Change Rd to Rt in div{u} result table

### DIFF
--- a/docs/cpuspecifications.md
+++ b/docs/cpuspecifications.md
@@ -322,7 +322,7 @@ additional slowdown.<br/>
 The hardware does NOT generate exceptions on divide overflows, instead, divide
 errors are returning the following values:<br/>
 ```
-  Opcode  Rs              Rd       Hi/Remainder  Lo/Result
+  Opcode  Rs              Rt       Hi/Remainder  Lo/Result
   divu    0..FFFFFFFFh    0   -->  Rs            FFFFFFFFh
   div     0..+7FFFFFFFh   0   -->  Rs            -1
   div     -80000000h..-1  0   -->  Rs            +1


### PR DESCRIPTION
It wouldn't make sense for `div`/`divu` to check if a register they don't use is 0. This is the only place `Rd` is used in reference to those instructions.